### PR TITLE
Location scoping 25 mile radius

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
         <entry key="app/src/main/res/drawable/ic_baseline_exit_to_app_24.xml" value="0.2375" />
         <entry key="app/src/main/res/drawable/rounded_buttons.xml" value="0.1755" />
         <entry key="app/src/main/res/drawable/rounded_text_field.xml" value="0.1755" />
-        <entry key="app/src/main/res/layout-v31/fragment_feed.xml" value="0.1" />
+        <entry key="app/src/main/res/layout-v31/fragment_feed.xml" value="0.25" />
         <entry key="app/src/main/res/layout-v31/fragment_home.xml" value="0.3280141843971631" />
         <entry key="app/src/main/res/layout/activity_app.xml" value="0.1702127659574468" />
         <entry key="app/src/main/res/layout/activity_calendar.xml" value="0.38958333333333334" />

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Connects user with lifestyle content from other journalers, reminders for the da
 - **Story:** Provides a safe space for indivduals finding themselves and using journaling as a guide to self discovery to connect. Strips away the societal pressures of being perfect and allows the user to just be.
 - **Market:** The app is marketed towards individual who enhoy journaling documenting their journey's in images; however, anyone can use the application.
 - **Habit:** Journey Journal will encourage users to utilize the app daily/ weekly to track their experiences, track their goal progress, and engage with user content.
-- **Scope:** Start with allowing the user to journal and set goals within the application. Next add the content sharing aspect. Then connect their calendars to the app so we can send reminders throughout the day to the user. Maybe later adding the ability to buy journal templates.
+- **Scope:** Start with allowing the user to journal and set goals within the application, add the content sharing aspect, add Journaling, and add user profile information. From here program the information to share offline.
 
 ## Product Spec
 
@@ -25,43 +25,71 @@ Connects user with lifestyle content from other journalers, reminders for the da
 
 **Required Must-have Stories**
 
-* Forced log in to connect user to their data
-* User can share content 
-* User can interact with other users by commenting on posts
+* User can log in to access account data
+* User can sign up to create a new account
+* User can view their profile and Journey post they have made
 * User can write and save private journals
-* User can set goals
+* User can set reminder/goals with location
+* User can share content in the Journey Feed
+* User can see post details on feed and in profile view upon click
+* User can view feed of of public posts created within 25 miles of the user
+* User can view and add applicaiton data offline (excluding post because of the ParseFile)
+
 
 **Optional Nice-to-have Stories**
 
-* Users can follow one another
-* Feed is split between following and User discovery
-* Chat feature for users to connect
-* User can buy journal templates
-* User can sell journal templates
+* User can click location in reminders and get direction to the location
+* User can edit profile (image, name, bio) in application
+* User can delete objects from application
+* Implementing a calendar function
+* User can interact with public posts by commenting (no liking because it often damages user mental health)
+
 
 
 ### 2. Screen Archetypes
 
-* Login - User signs up or logs into their account
-   * If not previously logged into the application, user will be prompted to login/ sign up to gain access to account information.
-   * ...
-* Home - Widget Screen where users can select the area of the application to explore
-* Journal Pad - Users can create new and view old journal entries
-* Content Feed - Users can view and upload content 
-* Checklist - Users can view and edit their schedule and goals
-   * [list associated required story here]
-   * ...
+* Login
+   * If not previously logged into the application, user will be prompted to login to access their account information
+
+* Sign Up
+  * User will be allowed to sign up to create a new account
+
+* Profile 
+  * User can view Journey Post, Profile Image, Username, and Bio in profile
+
+* Journal Pad 
+  * Users can create new and view old journal entries
+
+* Journey Feed 
+  * Users can view and upload content 
+
+* Reminder/Goals 
+  * Users can view their reminders and goals
+
+* Add Reminder/Goal
+  * User can view their reminders and goals while adding a new reminder/goal
+
+* Add Journey
+  * User can add a new Journey post (Description & Image) 
+
+* Journey Details
+  * User can view the details of the Journey post on click
+
+* Comments
+  * User can add and view comments on click of the comment button
 
 ### 3. Navigation
 
 **Tab Navigation** (Tab to Screen)
 
+* Reminder/Goals
+* Journey
+* Journals
 * Profile
-* Checklist
 
 **Optional**
 
-* Buy and Sell
+* Calendar Implementation (would be included in the Reminder/Goals Tab)
 
 ### 3. Wireframes 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,8 +40,8 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.navigation:navigation-fragment:2.5.0'
     implementation 'androidx.navigation:navigation-ui:2.5.0'
-    implementation 'com.google.android.gms:play-services-maps:18.0.2'
-    implementation 'com.google.android.libraries.places:places:2.4.0'
+    implementation 'com.google.android.gms:play-services-maps:18.1.0'
+    implementation 'com.google.android.libraries.places:places:2.6.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
@@ -61,9 +61,9 @@ dependencies {
     implementation 'com.google.maps.android:android-maps-utils:2.3.0'
     implementation 'com.google.maps.android:maps-utils-ktx:3.4.0'
 
+    implementation 'com.google.android.gms:play-services-location:20.0.0'
 
-
-    implementation "com.google.android.material:material:1.3.0-alpha02"
+    implementation "com.google.android.material:material:1.7.0-alpha03"
 
 
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,19 +50,19 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview:1.2.1"
 
     implementation 'com.github.bumptech.glide:glide:4.12.0'
-    // Glide v4 uses this new annotation processor -- see https://bumptech.github.io/glide/doc/generatedapi.html
+    // glide v4 uses this new annotation processor -- see https://bumptech.github.io/glide/doc/generatedapi.html
     annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
     implementation 'org.parceler:parceler-api:1.1.12'
     annotationProcessor 'org.parceler:parceler:1.1.12'
     implementation 'com.codepath.libraries:asynchttpclient:2.2.0'
 
-    //google places
+    // google places
     implementation 'com.google.android.libraries.places:places:2.6.0'
     implementation 'com.google.maps.android:android-maps-utils:2.3.0'
     implementation 'com.google.maps.android:maps-utils-ktx:3.4.0'
-
     implementation 'com.google.android.gms:play-services-location:20.0.0'
 
+    // material design
     implementation "com.google.android.material:material:1.7.0-alpha03"
 
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,13 +3,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.example.journeyjournal">
     <!-- Permissions needed to read calendar data and modify the data -->
-    <uses-sdk android:minSdkVersion="29" />
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES" />
 
 
@@ -94,6 +95,7 @@
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="@string/MAPS_API_KEY" />
+
 
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,8 +79,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".Activities.MainActivity"
-            />
+        <activity android:name=".Activities.MainActivity" />
         <activity android:name=".Activities.PostDetails" />
 
         <meta-data

--- a/app/src/main/java/com/example/journeyjournal/Activities/ComposePostActivity.java
+++ b/app/src/main/java/com/example/journeyjournal/Activities/ComposePostActivity.java
@@ -60,8 +60,6 @@ public class ComposePostActivity extends AppCompatActivity {
     ImageView ivImage;
     protected PostsAdapter adapter;
     protected List<Post> allPosts;
-    double latitude;
-    double longitude;
     LocationCallback mLocationCallback = new LocationCallback() {
         @Override
         public void onLocationResult(@NonNull LocationResult locationResult) {
@@ -71,6 +69,8 @@ public class ComposePostActivity extends AppCompatActivity {
             }
         }
     };
+    long MIN_DISTANCE = 2 * 1609;
+    long FASTEST_INTERVAL = 2000;
 
     User currentUser = (User) ParseUser.getCurrentUser();
 
@@ -134,11 +134,9 @@ public class ComposePostActivity extends AppCompatActivity {
         // Create the location request to start receiving updates
         LocationRequest mLocationRequest = LocationRequest.create();
         mLocationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
-        /* 10 secs */
-        long UPDATE_INTERVAL = 10 * 1000;
-        mLocationRequest.setInterval(UPDATE_INTERVAL);
+        /* 2 miles */
+        mLocationRequest.setInterval(MIN_DISTANCE);
         /* 2 sec */
-        long FASTEST_INTERVAL = 2000;
         mLocationRequest.setFastestInterval(FASTEST_INTERVAL);
 
         // Create LocationSettingsRequest object using location request
@@ -168,6 +166,8 @@ public class ComposePostActivity extends AppCompatActivity {
     }
 
     public void onLocationChanged(Location location) {
+        double latitude;
+        double longitude;
         // New location has now been determined
         latitude = location.getLatitude();
         longitude = location.getLongitude();

--- a/app/src/main/java/com/example/journeyjournal/Activities/ComposePostActivity.java
+++ b/app/src/main/java/com/example/journeyjournal/Activities/ComposePostActivity.java
@@ -108,6 +108,7 @@ public class ComposePostActivity extends AppCompatActivity {
                 }
                 if(wifi.isConnected()){
                     savePost(description, currentUser, photoFile);
+                    finish();
                 } else {
                     Toast.makeText(ComposePostActivity.this, "Can not add post without internet", Toast.LENGTH_LONG).show();
                 }
@@ -262,10 +263,4 @@ public class ComposePostActivity extends AppCompatActivity {
         }
 
 }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        LocationServices.getFusedLocationProviderClient(this).removeLocationUpdates(mLocationCallback);
-    }
 }

--- a/app/src/main/java/com/example/journeyjournal/Activities/ComposePostActivity.java
+++ b/app/src/main/java/com/example/journeyjournal/Activities/ComposePostActivity.java
@@ -1,28 +1,40 @@
 package com.example.journeyjournal.Activities;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityCompat;
 import androidx.core.content.FileProvider;
 
 import com.example.journeyjournal.Adapters.PostsAdapter;
-import com.example.journeyjournal.Adapters.ReminderAdapter;
 import com.example.journeyjournal.ParseConnectorFiles.Post;
-import com.example.journeyjournal.ParseConnectorFiles.Reminder;
 import com.example.journeyjournal.ParseConnectorFiles.User;
 import com.example.journeyjournal.R;
+import com.google.android.gms.location.LocationCallback;
+import com.google.android.gms.location.LocationRequest;
+import com.google.android.gms.location.LocationResult;
+import com.google.android.gms.location.LocationServices;
+import com.google.android.gms.location.LocationSettingsRequest;
+import com.google.android.gms.location.SettingsClient;
 import com.parse.ParseException;
 import com.parse.ParseFile;
+import com.parse.ParseGeoPoint;
 import com.parse.ParseUser;
 import com.parse.SaveCallback;
 
+import android.Manifest;
+import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.graphics.ImageDecoder;
+import android.location.Location;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
+import android.os.Looper;
 import android.provider.MediaStore;
 import android.util.Log;
 import android.view.View;
@@ -32,14 +44,13 @@ import android.widget.ImageView;
 import android.widget.Toast;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 @SuppressWarnings("deprecation")
 public class ComposePostActivity extends AppCompatActivity {
 
-    private static final String TAG = "MainActivity" ;
+    private static final String TAG = "ComposePost" ;
     private static final int CAPTURE_IMAGE_ACTIVITY_REQUEST_CODE = 42;
     private static final int PICK_PHOTO_CODE = 1046;
     EditText etDescription;
@@ -49,6 +60,19 @@ public class ComposePostActivity extends AppCompatActivity {
     ImageView ivImage;
     protected PostsAdapter adapter;
     protected List<Post> allPosts;
+    double latitude;
+    double longitude;
+    LocationCallback mLocationCallback = new LocationCallback() {
+        @Override
+        public void onLocationResult(@NonNull LocationResult locationResult) {
+            // do work here
+            if(locationResult.getLastLocation() != null){
+                onLocationChanged(locationResult.getLastLocation());
+            }
+        }
+    };
+
+    User currentUser = (User) ParseUser.getCurrentUser();
 
     File photoFile;
     public String photoFileName = "photo.jpg";
@@ -57,6 +81,9 @@ public class ComposePostActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_compose_post);
+        ConnectivityManager connManager = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo wifi = connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
+
 
         etDescription = findViewById(R.id.etDescription);
         btnImage = findViewById(R.id.btnImage);
@@ -79,8 +106,11 @@ public class ComposePostActivity extends AppCompatActivity {
                     Toast.makeText(ComposePostActivity.this, "No image", Toast.LENGTH_SHORT).show();
                     return;
                 }
-                User currentUser = (User) ParseUser.getCurrentUser();
-                savePost(description, currentUser, photoFile);
+                if(wifi.isConnected()){
+                    savePost(description, currentUser, photoFile);
+                } else {
+                    Toast.makeText(ComposePostActivity.this, "Can not add post without internet", Toast.LENGTH_LONG).show();
+                }
             }
         });
         btnImage.setOnClickListener(new View.OnClickListener() {
@@ -89,13 +119,61 @@ public class ComposePostActivity extends AppCompatActivity {
                 launchCamera();
             }
         });
-//        btnUpload.setOnClickListener(new View.OnClickListener() {
-//            @Override
-//            public void onClick(View v) {
-//               onUploadPhoto();
-//            }
-//        });
+    }
 
+    @Override
+    protected void onStart() {
+        super.onStart();
+        startLocationUpdates();
+    }
+
+    // Trigger new location updates at interval
+    protected void startLocationUpdates() {
+
+        // Create the location request to start receiving updates
+        LocationRequest mLocationRequest = LocationRequest.create();
+        mLocationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
+        /* 10 secs */
+        long UPDATE_INTERVAL = 10 * 1000;
+        mLocationRequest.setInterval(UPDATE_INTERVAL);
+        /* 2 sec */
+        long FASTEST_INTERVAL = 2000;
+        mLocationRequest.setFastestInterval(FASTEST_INTERVAL);
+
+        // Create LocationSettingsRequest object using location request
+        LocationSettingsRequest.Builder builder = new LocationSettingsRequest.Builder();
+        builder.addLocationRequest(mLocationRequest);
+        LocationSettingsRequest locationSettingsRequest = builder.build();
+
+        // Check whether location settings are satisfied
+        // https://developers.google.com/android/reference/com/google/android/gms/location/SettingsClient
+        SettingsClient settingsClient = LocationServices.getSettingsClient(this);
+        settingsClient.checkLocationSettings(locationSettingsRequest);
+
+        // new Google API SDK v11 uses getFusedLocationProviderClient(this)
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) !=
+                PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(this,
+                Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            requestPermissions(
+                    new String[] {
+                            Manifest.permission.ACCESS_FINE_LOCATION,
+                            Manifest.permission.ACCESS_COARSE_LOCATION },
+                    100);
+            return;
+        }
+        LocationServices.getFusedLocationProviderClient(this).requestLocationUpdates(mLocationRequest, mLocationCallback, Looper.myLooper());
+        Toast.makeText(this, "Permission ok", Toast.LENGTH_SHORT).show();
+
+    }
+
+    public void onLocationChanged(Location location) {
+        // New location has now been determined
+        latitude = location.getLatitude();
+        longitude = location.getLongitude();
+        ParseGeoPoint location1 = new ParseGeoPoint(latitude, longitude);
+        currentUser.setLocation(location1);
+        String msg = "Updated Location: " + latitude + "," + longitude;
+        Toast.makeText(this, msg, Toast.LENGTH_LONG).show();
     }
 
 
@@ -143,20 +221,10 @@ public class ComposePostActivity extends AppCompatActivity {
         post.setDescription(description);
         post.setImage(new ParseFile(this.photoFile));
         post.setUser(currentUser);
-
-        post.pinAllInBackground(allPosts, new SaveCallback() {
-            @Override
-            public void done(ParseException e) {
-                if (e != null) {
-                    Log.e(TAG, "Error adding reminder", e);
-                    return;
-                }
-                Log.i(TAG, "Post was successful");
-                etDescription.setText("");
-                ivImage.setImageResource(0);
-                finish();
-            }
-        });
+        post.setLocation(currentUser.getLocation());
+        // saves data in data store with label
+        post.pinInBackground("Posts");
+        // saves change to parse when there is internet
         post.saveInBackground(new SaveCallback() {
             @Override
             public void done(ParseException e) {
@@ -194,4 +262,10 @@ public class ComposePostActivity extends AppCompatActivity {
         }
 
 }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        LocationServices.getFusedLocationProviderClient(this).removeLocationUpdates(mLocationCallback);
+    }
 }

--- a/app/src/main/java/com/example/journeyjournal/Activities/ComposePostActivity.java
+++ b/app/src/main/java/com/example/journeyjournal/Activities/ComposePostActivity.java
@@ -50,7 +50,7 @@ import java.util.List;
 @SuppressWarnings("deprecation")
 public class ComposePostActivity extends AppCompatActivity {
 
-    private static final String TAG = "ComposePost" ;
+    private static final String TAG = "ComposePost";
     private static final int CAPTURE_IMAGE_ACTIVITY_REQUEST_CODE = 42;
     private static final int PICK_PHOTO_CODE = 1046;
     EditText etDescription;
@@ -66,7 +66,7 @@ public class ComposePostActivity extends AppCompatActivity {
         @Override
         public void onLocationResult(@NonNull LocationResult locationResult) {
             // do work here
-            if(locationResult.getLastLocation() != null){
+            if (locationResult.getLastLocation() != null) {
                 onLocationChanged(locationResult.getLastLocation());
             }
         }
@@ -98,15 +98,15 @@ public class ComposePostActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 String description = etDescription.getText().toString();
-                if(description.isEmpty()){
+                if (description.isEmpty()) {
                     Toast.makeText(ComposePostActivity.this, "Description cannot be empty", Toast.LENGTH_SHORT).show();
                     return;
                 }
-                if(photoFile == null || ivImage.getDrawable() == null) {
+                if (photoFile == null || ivImage.getDrawable() == null) {
                     Toast.makeText(ComposePostActivity.this, "No image", Toast.LENGTH_SHORT).show();
                     return;
                 }
-                if(wifi.isConnected()){
+                if (wifi.isConnected()) {
                     savePost(description, currentUser, photoFile);
                     finish();
                 } else {
@@ -156,9 +156,9 @@ public class ComposePostActivity extends AppCompatActivity {
                 PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(this,
                 Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
             requestPermissions(
-                    new String[] {
+                    new String[]{
                             Manifest.permission.ACCESS_FINE_LOCATION,
-                            Manifest.permission.ACCESS_COARSE_LOCATION },
+                            Manifest.permission.ACCESS_COARSE_LOCATION},
                     100);
             return;
         }
@@ -200,7 +200,6 @@ public class ComposePostActivity extends AppCompatActivity {
     }
 
 
-
     // Returns the File for a photo stored on disk given the fileName
     private File getPhotoFileUri(String fileName) {
         // Get safe storage directory for photos using `getExternalFilesDir` on Context to access package-specific directories
@@ -208,7 +207,7 @@ public class ComposePostActivity extends AppCompatActivity {
         File mediaStorageDir = new File(getExternalFilesDir(Environment.DIRECTORY_PICTURES), TAG);
 
         // Create the storage directory if it does not exist
-        if (!mediaStorageDir.exists() && !mediaStorageDir.mkdirs()){
+        if (!mediaStorageDir.exists() && !mediaStorageDir.mkdirs()) {
             Log.d(TAG, "failed to create directory");
         }
 
@@ -229,7 +228,7 @@ public class ComposePostActivity extends AppCompatActivity {
         post.saveInBackground(new SaveCallback() {
             @Override
             public void done(ParseException e) {
-                if(e != null){
+                if (e != null) {
                     Log.e(TAG, "Error while saving", e);
                     Toast.makeText(ComposePostActivity.this, "Error while saving", Toast.LENGTH_SHORT).show();
                 }
@@ -262,5 +261,5 @@ public class ComposePostActivity extends AppCompatActivity {
                 break;
         }
 
-}
+    }
 }

--- a/app/src/main/java/com/example/journeyjournal/ParseConnectorFiles/Post.java
+++ b/app/src/main/java/com/example/journeyjournal/ParseConnectorFiles/Post.java
@@ -20,24 +20,27 @@ public class Post extends ParseObject {
     public static final String KEY_LOCATION = "location";
 
 
-
     // gets description for the post
-    public String getDescription(){
+    public String getDescription() {
         return getString(KEY_DESCRIPTION);
 
     }
+
     // set description for the post
-    public void setDescription(String description){
+    public void setDescription(String description) {
         put(KEY_DESCRIPTION, description);
     }
+
     // gets image for the post
-    public ParseFile getImage(){
+    public ParseFile getImage() {
         return getParseFile(KEY_IMAGE);
     }
+
     //sets image for the post
-    public void setImage(ParseFile parseFile){
+    public void setImage(ParseFile parseFile) {
         put(KEY_IMAGE, parseFile);
     }
+
     // gets the user that created the post
     public ParseUser getUser() {
         return getParseUser(KEY_USER);
@@ -50,7 +53,6 @@ public class Post extends ParseObject {
     public void setLocation(ParseGeoPoint location) {
         put(KEY_LOCATION, location);
     }
-
 
 
     // calculates how long ago the post was made
@@ -88,5 +90,4 @@ public class Post extends ParseObject {
 
         return "";
     }
-
 }

--- a/app/src/main/java/com/example/journeyjournal/ParseConnectorFiles/Post.java
+++ b/app/src/main/java/com/example/journeyjournal/ParseConnectorFiles/Post.java
@@ -17,7 +17,8 @@ public class Post extends ParseObject {
     public static final String KEY_DESCRIPTION = "description";
     public static final String KEY_IMAGE = "image";
     public static final String KEY_USER = "user";
-    public static final String KEY_LOCATION = "postMade";
+    public static final String KEY_LOCATION = "location";
+
 
 
     // gets description for the post
@@ -46,13 +47,11 @@ public class Post extends ParseObject {
         put(KEY_USER, user);
     }
 
-    public ParseGeoPoint getLocation() {
-        return getParseGeoPoint(KEY_LOCATION);
-    }
-
     public void setLocation(ParseGeoPoint location) {
         put(KEY_LOCATION, location);
     }
+
+
 
     // calculates how long ago the post was made
     public static String timeAgo(Date createdAt) {

--- a/app/src/main/java/com/example/journeyjournal/ParseConnectorFiles/Post.java
+++ b/app/src/main/java/com/example/journeyjournal/ParseConnectorFiles/Post.java
@@ -4,6 +4,7 @@ import android.util.Log;
 
 import com.parse.ParseClassName;
 import com.parse.ParseFile;
+import com.parse.ParseGeoPoint;
 import com.parse.ParseObject;
 import com.parse.ParseUser;
 
@@ -42,6 +43,14 @@ public class Post extends ParseObject {
 
     public void setUser(ParseUser user) {
         put(KEY_USER, user);
+    }
+
+    public ParseGeoPoint getLocation() {
+        return getParseGeoPoint(User.KEY_LOCATION);
+    }
+
+    public void setLocation(ParseGeoPoint location) {
+        put(User.KEY_LOCATION, location);
     }
 
     // calculates how long ago the post was made

--- a/app/src/main/java/com/example/journeyjournal/ParseConnectorFiles/Post.java
+++ b/app/src/main/java/com/example/journeyjournal/ParseConnectorFiles/Post.java
@@ -17,6 +17,7 @@ public class Post extends ParseObject {
     public static final String KEY_DESCRIPTION = "description";
     public static final String KEY_IMAGE = "image";
     public static final String KEY_USER = "user";
+    public static final String KEY_LOCATION = "postMade";
 
 
     // gets description for the post
@@ -46,11 +47,11 @@ public class Post extends ParseObject {
     }
 
     public ParseGeoPoint getLocation() {
-        return getParseGeoPoint(User.KEY_LOCATION);
+        return getParseGeoPoint(KEY_LOCATION);
     }
 
     public void setLocation(ParseGeoPoint location) {
-        put(User.KEY_LOCATION, location);
+        put(KEY_LOCATION, location);
     }
 
     // calculates how long ago the post was made

--- a/app/src/main/java/com/example/journeyjournal/ParseConnectorFiles/User.java
+++ b/app/src/main/java/com/example/journeyjournal/ParseConnectorFiles/User.java
@@ -14,7 +14,6 @@ public class User extends ParseUser {
     public static final String KEY_BIO = "bio";
     public static final String KEY_LOCATION = "location";
 
-
     public ParseFile getProfileImage() {
         return getParseFile(KEY_PROFILE_PIC);
     }
@@ -46,6 +45,5 @@ public class User extends ParseUser {
     public void setLocation(ParseGeoPoint location) {
         put(KEY_LOCATION, location);
     }
-
 
 }

--- a/app/src/main/java/com/example/journeyjournal/ParseConnectorFiles/User.java
+++ b/app/src/main/java/com/example/journeyjournal/ParseConnectorFiles/User.java
@@ -2,6 +2,7 @@ package com.example.journeyjournal.ParseConnectorFiles;
 
 import com.parse.ParseClassName;
 import com.parse.ParseFile;
+import com.parse.ParseGeoPoint;
 import com.parse.ParseUser;
 
 
@@ -11,6 +12,8 @@ public class User extends ParseUser {
     public static final String KEY_PROFILE_PIC = "profilePic";
     public static final String KEY_USERNAME = "username";
     public static final String KEY_BIO = "bio";
+    public static final String KEY_LOCATION = "location";
+
 
     public ParseFile getProfileImage() {
         return getParseFile(KEY_PROFILE_PIC);
@@ -35,5 +38,14 @@ public class User extends ParseUser {
     public void setBio(String bio) {
         put(KEY_BIO, bio);
     }
+
+    public ParseGeoPoint getLocation() {
+        return getParseGeoPoint(KEY_LOCATION);
+    }
+
+    public void setLocation(ParseGeoPoint location) {
+        put(KEY_LOCATION, location);
+    }
+
 
 }

--- a/app/src/main/java/com/example/journeyjournal/fragments/FeedFragment.java
+++ b/app/src/main/java/com/example/journeyjournal/fragments/FeedFragment.java
@@ -1,18 +1,24 @@
 package com.example.journeyjournal.fragments;
 
+import android.Manifest;
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.location.Location;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
+import android.os.Looper;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -21,12 +27,17 @@ import android.widget.ImageButton;
 import android.widget.Toast;
 
 import com.example.journeyjournal.Activities.ComposePostActivity;
-import com.example.journeyjournal.Activities.RemindersActivity;
 import com.example.journeyjournal.ParseConnectorFiles.Post;
 import com.example.journeyjournal.Adapters.PostsAdapter;
 import com.example.journeyjournal.Activities.LoginActivity;
-import com.example.journeyjournal.ParseConnectorFiles.Reminder;
 import com.example.journeyjournal.R;
+import com.google.android.gms.location.LocationCallback;
+import com.google.android.gms.location.LocationResult;
+import com.google.android.gms.location.LocationServices;
+import com.google.android.gms.location.LocationSettingsRequest;
+import com.google.android.gms.location.LocationRequest;
+import com.google.android.gms.location.SettingsClient;
+import com.parse.DeleteCallback;
 import com.parse.FindCallback;
 import com.parse.ParseException;
 import com.parse.ParseQuery;
@@ -35,6 +46,7 @@ import com.parse.ParseUser;
 import java.util.ArrayList;
 import java.util.List;
 
+@SuppressWarnings("deprecation")
 public class FeedFragment extends Fragment {
     private static final String TAG = "FeedFragment";
     private SwipeRefreshLayout swipeContainer;
@@ -44,21 +56,19 @@ public class FeedFragment extends Fragment {
     protected PostsAdapter adapter;
     protected List<Post> allPosts;
 
+    double longitude;
+    double latitude;
+
     public FeedFragment() {
     }
 
     @Override
     public void onResume() {
         super.onResume();
-        ConnectivityManager connManager = (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo wifi = connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-        if(wifi.isConnected()){
-            // query posts from the database
-            Log.i(TAG, "onResume");
-            adapter.clear();
-            queryPosts();
-        } else {
-            querySavedPosts();}
+        // query posts from the database
+        Log.i(TAG, "onResume");
+        adapter.clear();
+        querySavedPosts();
     }
 
     @Override
@@ -70,7 +80,8 @@ public class FeedFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        ConnectivityManager connManager = (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
+        startLocationUpdates();
+        ConnectivityManager connManager = (ConnectivityManager) requireActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo wifi = connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
 
         ibLogout = view.findViewById(R.id.ibLogout);
@@ -83,29 +94,18 @@ public class FeedFragment extends Fragment {
         rvPosts.setAdapter(adapter);
         // set the layout manager on the recycler view
         rvPosts.setLayoutManager(new LinearLayoutManager(getContext()));
-        if(wifi.isConnected()){
-            // query posts from the database
-            Log.i(TAG, "onResume");
-            adapter.clear();
-            queryPosts();
-        } else {
-            querySavedPosts();}
+        querySavedPosts();
 
         swipeContainer = (SwipeRefreshLayout) view.findViewById(R.id.swipeContainer);
         // Setup refresh listener which triggers new data loading
-        swipeContainer.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
-            @Override
-            public void onRefresh() {
-                // Your code to refresh the list here.
-                // Make sure you call swipeContainer.setRefreshing(false)
-                // once the network request has completed successfully.
-                if(wifi.isConnected()){
-                    // query posts from the database
-                    Log.i(TAG, "onResume");
-                    adapter.clear();
-                    queryPosts();
-                } else {
-                    querySavedPosts();}
+        swipeContainer.setOnRefreshListener(() -> {
+            // Your code to refresh the list here.
+            // Make sure you call swipeContainer.setRefreshing(false)
+            // once the network request has completed successfully.
+            if (wifi.isConnected()) {
+                queryPosts();
+            } else {
+                querySavedPosts();
             }
         });
         // Configure the refreshing colors
@@ -118,10 +118,9 @@ public class FeedFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 ParseUser.logOut();
-                ParseUser currentUser = ParseUser.getCurrentUser();
-                Intent i = new Intent(getContext(), LoginActivity.class);
-                startActivity(i);
-                getActivity().finish();
+                Intent intent = new Intent(getContext(), LoginActivity.class);
+                startActivity(intent);
+                requireActivity().finish();
             }
         });
 
@@ -133,17 +132,68 @@ public class FeedFragment extends Fragment {
         });
     }
 
-    private void goNewPost() {
-        ConnectivityManager connManager = (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo wifi = connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-        if(wifi.isConnected()){
-            Intent intent = new Intent(getActivity(), ComposePostActivity.class);
-            startActivity(intent);
-        } else {
-            Toast.makeText(getContext(), "Please connect to the internet", Toast.LENGTH_LONG).show();
+    // Trigger new location updates at interval
+    protected void startLocationUpdates() {
+
+        // Create the location request to start receiving updates
+        LocationRequest mLocationRequest = LocationRequest.create();
+        mLocationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
+        /* 10 secs */
+        long UPDATE_INTERVAL = 10 * 1000;
+        mLocationRequest.setInterval(UPDATE_INTERVAL);
+        /* 2 sec */
+        long FASTEST_INTERVAL = 2000;
+        mLocationRequest.setFastestInterval(FASTEST_INTERVAL);
+
+        // Create LocationSettingsRequest object using location request
+        LocationSettingsRequest.Builder builder = new LocationSettingsRequest.Builder();
+        builder.addLocationRequest(mLocationRequest);
+        LocationSettingsRequest locationSettingsRequest = builder.build();
+
+        // Check whether location settings are satisfied
+        // https://developers.google.com/android/reference/com/google/android/gms/location/SettingsClient
+        SettingsClient settingsClient = LocationServices.getSettingsClient(requireActivity());
+        settingsClient.checkLocationSettings(locationSettingsRequest);
+
+        // new Google API SDK v11 uses getFusedLocationProviderClient(this)
+        if (ActivityCompat.checkSelfPermission(requireActivity(), Manifest.permission.ACCESS_FINE_LOCATION) !=
+                PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(requireActivity(),
+                Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            requestPermissions(
+                    new String[] {
+                            Manifest.permission.ACCESS_FINE_LOCATION,
+                            Manifest.permission.ACCESS_COARSE_LOCATION },
+                    100);
+            return;
         }
+        LocationServices.getFusedLocationProviderClient(requireActivity()).requestLocationUpdates(mLocationRequest, new LocationCallback() {
+                    @Override
+                    public void onLocationResult(LocationResult locationResult) {
+                        // do work here
+                        onLocationChanged(locationResult.getLastLocation());
+                    }
+                },
+                Looper.myLooper());
+        Toast.makeText(getActivity(), "Permission ok", Toast.LENGTH_SHORT).show();
+
     }
 
+    public void onLocationChanged(Location location) {
+        // New location has now been determined
+        latitude = location.getLatitude();
+        longitude = location.getLongitude();
+        String msg = "Updated Location: " +
+                latitude + "," +
+                longitude;
+        Toast.makeText(getActivity(), "on location changed", Toast.LENGTH_SHORT).show();
+        Toast.makeText(getActivity(), msg, Toast.LENGTH_LONG).show();
+    }
+
+
+    private void goNewPost() {
+        Intent intent = new Intent(getActivity(), ComposePostActivity.class);
+        startActivity(intent);
+    }
 
     private void queryPosts() {
         // specify what type of data we want to query - Post.class
@@ -153,11 +203,23 @@ public class FeedFragment extends Fragment {
         query.setLimit(20);
         query.setSkip(0);
         // order posts by creation date (newest first)
-        query.addDescendingOrder("createdAt");
+        query.addDescendingOrder(Post.KEY_CREATED_AT);
         // start an asynchronous call for posts
         query.findInBackground(new FindCallback<Post>() {
+            @SuppressLint("NotifyDataSetChanged")
             @Override
             public void done(List<Post> posts, ParseException e) {
+
+                Post.unpinAllInBackground(posts);
+
+                // Remove the previously cached results.
+                Post.unpinAllInBackground("Posts", new DeleteCallback() {
+                    public void done(ParseException e) {
+                        // Cache the new results.
+                        Post.pinAllInBackground("Posts", posts);
+                    }
+                });
+
                 if (e != null) {
                     Log.e(TAG, "Issue with getting posts", e);
                     return;
@@ -174,29 +236,33 @@ public class FeedFragment extends Fragment {
         });
     }
 
-    private void querySavedPosts(){
+    protected void querySavedPosts() {
         ParseQuery<Post> query = ParseQuery.getQuery(Post.class);
         query.include(Post.KEY_USER);
-        query.whereEqualTo(Post.KEY_USER, ParseUser.getCurrentUser());
+        query.addDescendingOrder(Post.KEY_CREATED_AT);
         query.fromLocalDatastore();
-        query.addDescendingOrder("createdAt");
         query.findInBackground(new FindCallback<Post>() {
+            @SuppressLint("NotifyDataSetChanged")
             @Override
             public void done(List<Post> posts, ParseException e) {
-                // check for failure
+                Log.i(TAG, posts.toString());
+
                 if (e != null) {
-                    Log.e(TAG, "Failure to load saved reminders", e);
+                    Log.e(TAG, "Issue getting posts.", e);
                     return;
                 }
-                // prints every reminder description for debugging purposes
-                for (Post post : posts){
+
+                // at this point, we have gotten the posts successfully
+                for (Post post : posts) {
                     Log.i(TAG, "Post: " + post.getDescription() + ", username: " + post.getUser().getUsername());
                 }
-                // save received comments to list and notify adapter of change
+
                 allPosts.clear();
                 allPosts.addAll(posts);
                 adapter.notifyDataSetChanged();
                 swipeContainer.setRefreshing(false);
-            }});
+            }
+        });
     }
 }
+

--- a/app/src/main/java/com/example/journeyjournal/fragments/FeedFragment.java
+++ b/app/src/main/java/com/example/journeyjournal/fragments/FeedFragment.java
@@ -204,8 +204,8 @@ public class FeedFragment extends Fragment {
         query.setLimit(20);
         query.setSkip(0);
 
-        // query posts that are from users within 25 miles of the user location
-        query.whereWithinMiles(Post.KEY_USER, user.getLocation(), 25.0);
+        // query posts that were created within 25 miles of the user location
+        query.whereWithinMiles(Post.KEY_LOCATION, user.getLocation(), 25.0);
         // order posts by creation date (newest first)
         query.addDescendingOrder(Post.KEY_CREATED_AT);
         // start an asynchronous call for posts
@@ -213,16 +213,21 @@ public class FeedFragment extends Fragment {
             @SuppressLint("NotifyDataSetChanged")
             @Override
             public void done(List<Post> posts, ParseException e) {
-
-                Post.unpinAllInBackground(posts);
+                Log.i(TAG, posts.toString());
 
                 // Remove the previously cached results.
                 Post.unpinAllInBackground("Posts", new DeleteCallback() {
                     public void done(ParseException e) {
+                        if (e != null) {
+                            Log.e(TAG, "Issue with unpinning posts", e);
+                            return;
+                        }
                         // Cache the new results.
+                        Log.i(TAG, "posts deleted and added");
                         Post.pinAllInBackground("Posts", posts);
                     }
                 });
+
 
                 if (e != null) {
                     Log.e(TAG, "Issue with getting posts", e);
@@ -283,7 +288,6 @@ public class FeedFragment extends Fragment {
     @Override
     public void onPause() {
         super.onPause();
-
         LocationServices.getFusedLocationProviderClient(requireActivity()).removeLocationUpdates(mLocationCallback);
     }
 

--- a/app/src/main/java/com/example/journeyjournal/fragments/FeedFragment.java
+++ b/app/src/main/java/com/example/journeyjournal/fragments/FeedFragment.java
@@ -65,7 +65,7 @@ public class FeedFragment extends Fragment {
         @Override
         public void onLocationResult(@NonNull LocationResult locationResult) {
             // do work here
-            if(locationResult.getLastLocation() != null){
+            if (locationResult.getLastLocation() != null) {
                 onLocationChanged(locationResult.getLastLocation());
             }
         }
@@ -83,7 +83,7 @@ public class FeedFragment extends Fragment {
         Log.i(TAG, "onResume");
         adapter.clear();
         whichQuery();
-        if(wifi.isConnected()){
+        if (wifi.isConnected()) {
             startLocationUpdates();
         }
     }
@@ -168,9 +168,9 @@ public class FeedFragment extends Fragment {
                 PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(requireActivity(),
                 Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
             requestPermissions(
-                    new String[] {
+                    new String[]{
                             Manifest.permission.ACCESS_FINE_LOCATION,
-                            Manifest.permission.ACCESS_COARSE_LOCATION },
+                            Manifest.permission.ACCESS_COARSE_LOCATION},
                     100);
             return;
         }
@@ -178,9 +178,9 @@ public class FeedFragment extends Fragment {
                 PackageManager.PERMISSION_DENIED && ActivityCompat.checkSelfPermission(requireActivity(),
                 Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_DENIED) {
             requestPermissions(
-                    new String[] {
+                    new String[]{
                             Manifest.permission.ACCESS_FINE_LOCATION,
-                            Manifest.permission.ACCESS_COARSE_LOCATION },
+                            Manifest.permission.ACCESS_COARSE_LOCATION},
                     100);
             Log.i(TAG, "permission denied ask");
             return;
@@ -213,6 +213,8 @@ public class FeedFragment extends Fragment {
         query.include(Post.KEY_USER);
         query.setLimit(20);
         query.setSkip(0);
+
+        // TODO - add more scoping constraints (followings, user interest)
 
         // query posts that were created within 25 miles of the user location
         query.whereWithinMiles(Post.KEY_LOCATION, currentUser.getLocation(), 25.0);
@@ -287,7 +289,7 @@ public class FeedFragment extends Fragment {
     private void whichQuery() {
         ConnectivityManager connManager = (ConnectivityManager) requireActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo wifi = connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-        if(wifi.isConnected()){
+        if (wifi.isConnected()) {
             queryPosts();
             startLocationUpdates();
         } else {

--- a/app/src/main/java/com/example/journeyjournal/fragments/FeedFragment.java
+++ b/app/src/main/java/com/example/journeyjournal/fragments/FeedFragment.java
@@ -189,11 +189,8 @@ public class FeedFragment extends Fragment {
     }
 
     public void onLocationChanged(Location location) {
-        double longitude;
-        double latitude;
-        // New location has now been determined
-        latitude = location.getLatitude();
-        longitude = location.getLongitude();
+        double latitude = location.getLatitude();
+        double longitude = location.getLongitude();
         ParseGeoPoint location1 = new ParseGeoPoint(latitude, longitude);
         currentUser.setLocation(location1);
         String msg = "Updated Location: " + latitude + "," + longitude;

--- a/app/src/main/java/com/example/journeyjournal/fragments/FeedFragment.java
+++ b/app/src/main/java/com/example/journeyjournal/fragments/FeedFragment.java
@@ -58,8 +58,6 @@ public class FeedFragment extends Fragment {
     protected PostsAdapter adapter;
     protected List<Post> allPosts;
 
-    double longitude;
-    double latitude;
     private final User currentUser = (User) ParseUser.getCurrentUser();
     LocationCallback mLocationCallback = new LocationCallback() {
         @Override
@@ -70,6 +68,8 @@ public class FeedFragment extends Fragment {
             }
         }
     };
+    long MIN_DISTANCE = 2 * 1609;
+    long FASTEST_INTERVAL = 2000;
 
     public FeedFragment() {
     }
@@ -147,10 +147,8 @@ public class FeedFragment extends Fragment {
         LocationRequest mLocationRequest = LocationRequest.create();
         mLocationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
         /* 2 Mile */
-        long MIN_DISTANCE = 2 * 1609;
         mLocationRequest.setInterval(MIN_DISTANCE);
         /* 60 sec */
-        long FASTEST_INTERVAL = 600000;
         mLocationRequest.setFastestInterval(FASTEST_INTERVAL);
 
         // Create LocationSettingsRequest object using location request
@@ -191,6 +189,8 @@ public class FeedFragment extends Fragment {
     }
 
     public void onLocationChanged(Location location) {
+        double longitude;
+        double latitude;
         // New location has now been determined
         latitude = location.getLatitude();
         longitude = location.getLongitude();


### PR DESCRIPTION
Implemented data constraints that will only query posts (ParseObject) created within a 25 mile radius of the current user's current location. To do this, I used the Connectivity Manger to establish whether there is wifi to run Google Play location services. If wifi, the application prompts the user to allow location access, if not already granted. Once granted, a location request is ran on a loop every 2 miles or 60 seconds using getFusedLocationProviderClient location updates. The application tracks the updates and assigns the user current location Parse as it changes. When queried, the application runs a Parse Query for the posts created in the surrounding area. To know what where the post is made, location tracking is added to the compose post activity, and the user location at the time of posting is added the a new post when it is saved.

Following this, I want to add user can view post of people they are following and querying based on user interest.

![Problem2](https://user-images.githubusercontent.com/93938197/180499910-3eebcece-096d-4b08-a88c-19f06355a8d4.gif)
